### PR TITLE
Non-destructive topology creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ var topology = topojson.topology({foo: geojson});
 
 <a name="topology" href="#topology">#</a> topojson.<b>topology</b>(<i>objects</i>[, <i>quantization</i>]) [<>](https://github.com/topojson/topojson-server/blob/master/src/topology.js "Source")
 
-Converts the specified [GeoJSON *objects*](http://geojson.org/geojson-spec.html#geojson-objects) to TopoJSON.
+Returns a TopoJSON topology for the specified [GeoJSON *objects*](http://geojson.org/geojson-spec.html#geojson-objects).
 
-**CAUTION:** The input *objects* are modified **in-place** and should not be referenced after calling this method; this is a destructive operation!
-
-If a *quantization* parameter is specified, the input geometry is quantized prior to computing the topology, and the returned topology is quantized, and its arcs are [delta-encoded](https://github.com/topojson/topojson-specification/blob/master/README.md#213-arcs). Quantization is recommended to improve the quality of the topology if the input geometry is messy (*i.e.*, small floating point error means that adjacent boundaries do not have identical values); typical values are powers of ten, such as 1e4, 1e5 or 1e6. See also [topojson.quantize](https://github.com/topojson/topojson-client/blob/master/README.md#quantize) to quantize a topology after it has been constructed, without altering the topological relationships.
+If a *quantization* parameter is specified, the input geometry is quantized prior to computing the topology, the returned topology is quantized, and its arcs are [delta-encoded](https://github.com/topojson/topojson-specification/blob/master/README.md#213-arcs). Quantization is recommended to improve the quality of the topology if the input geometry is messy (*i.e.*, small floating point error means that adjacent boundaries do not have identical values); typical values are powers of ten, such as 1e4, 1e5 or 1e6. See also [topojson.quantize](https://github.com/topojson/topojson-client/blob/master/README.md#quantize) to quantize a topology after it has been constructed, without altering the topological relationships.
 
 ## Command-Line Reference
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See [shapefile](https://github.com/mbostock/shapefile) for converting ESRI shape
 If you use NPM, `npm install topojson-server`. Otherwise, download the [latest release](https://github.com/topojson/topojson-server/releases/latest). You can also load directly from [unpkg](https://unpkg.com). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `topojson` global is exported:
 
 ```html
-<script src="https://unpkg.com/topojson-server@2"></script>
+<script src="https://unpkg.com/topojson-server@3"></script>
 <script>
 
 var topology = topojson.topology({foo: geojson});

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var topology = topojson.topology({foo: geojson});
 
 <a name="topology" href="#topology">#</a> topojson.<b>topology</b>(<i>objects</i>[, <i>quantization</i>]) [<>](https://github.com/topojson/topojson-server/blob/master/src/topology.js "Source")
 
-Returns a TopoJSON topology for the specified [GeoJSON *objects*](http://geojson.org/geojson-spec.html#geojson-objects).
+Returns a TopoJSON topology for the specified [GeoJSON *objects*](http://geojson.org/geojson-spec.html#geojson-objects). The returned topology makes a shallow copy of the input *objects*: the identifier, bounding box, properties and coordinates of input objects may be shared with the output topology.
 
 If a *quantization* parameter is specified, the input geometry is quantized prior to computing the topology, the returned topology is quantized, and its arcs are [delta-encoded](https://github.com/topojson/topojson-specification/blob/master/README.md#213-arcs). Quantization is recommended to improve the quality of the topology if the input geometry is messy (*i.e.*, small floating point error means that adjacent boundaries do not have identical values); typical values are powers of ten, such as 1e4, 1e5 or 1e6. See also [topojson.quantize](https://github.com/topojson/topojson-client/blob/master/README.md#quantize) to quantize a topology after it has been constructed, without altering the topological relationships.
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "eslint": "3",
     "package-preamble": "0.0",
-    "rollup": "0.36",
+    "rollup": "0.41",
     "tape": "4",
     "topojson-client": "2",
     "uglify-js": "2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topojson-server",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Convert GeoJSON to TopoJSON for smaller files and the power of topology!",
   "keywords": [
     "topojson",
@@ -35,7 +35,7 @@
     "package-preamble": "0.0",
     "rollup": "0.41",
     "tape": "4",
-    "topojson-client": "2",
+    "topojson-client": "3",
     "uglify-js": "2"
   }
 }

--- a/src/bounds.js
+++ b/src/bounds.js
@@ -13,10 +13,10 @@ export default function(objects) {
     GeometryCollection: function(o) { o.geometries.forEach(boundGeometry); },
     Point: function(o) { boundPoint(o.coordinates); },
     MultiPoint: function(o) { o.coordinates.forEach(boundPoint); },
-    LineString: function(o) { boundLine(o.coordinates); },
-    MultiLineString: function(o) { o.coordinates.forEach(boundLine); },
-    Polygon: function(o) { o.coordinates.forEach(boundLine); },
-    MultiPolygon: function(o) { o.coordinates.forEach(boundMultiLine); }
+    LineString: function(o) { boundLine(o.arcs); },
+    MultiLineString: function(o) { o.arcs.forEach(boundLine); },
+    Polygon: function(o) { o.arcs.forEach(boundLine); },
+    MultiPolygon: function(o) { o.arcs.forEach(boundMultiLine); }
   };
 
   function boundPoint(coordinates) {

--- a/src/bounds.js
+++ b/src/bounds.js
@@ -6,7 +6,7 @@ export default function(objects) {
       y1 = -Infinity;
 
   function boundGeometry(geometry) {
-    if (geometry && boundGeometryType.hasOwnProperty(geometry.type)) boundGeometryType[geometry.type](geometry);
+    if (geometry != null && boundGeometryType.hasOwnProperty(geometry.type)) boundGeometryType[geometry.type](geometry);
   }
 
   var boundGeometryType = {

--- a/src/delta.js
+++ b/src/delta.js
@@ -1,29 +1,30 @@
-// Given a TopoJSON topology in absolute (quantized) coordinates,
+// Given an array of arcs in absolute (but already quantized!) coordinates,
 // converts to fixed-point delta encoding.
-// This is a destructive operation that modifies the given topology!
-export default function(topology) {
-  var arcs = topology.arcs,
-      i = -1,
+// This is a destructive operation that modifies the given arcs!
+export default function(arcs) {
+  var i = -1,
       n = arcs.length;
 
   while (++i < n) {
     var arc = arcs[i],
         j = 0,
+        k = 1,
         m = arc.length,
         point = arc[0],
         x0 = point[0],
         y0 = point[1],
         x1,
         y1;
+
     while (++j < m) {
-      point = arc[j];
-      x1 = point[0];
-      y1 = point[1];
-      arc[j] = [x1 - x0, y1 - y0];
-      x0 = x1;
-      y0 = y1;
+      point = arc[j], x1 = point[0], y1 = point[1];
+      if (x1 !== x0 || y1 !== y0) arc[k++] = [x1 - x0, y1 - y0], x0 = x1, y0 = y1;
     }
+
+    if (k === 1) arc[k++] = [0, 0]; // Each arc must be an array of two or more positions.
+
+    arc.length = k;
   }
 
-  return topology;
+  return arcs;
 }

--- a/src/extract.js
+++ b/src/extract.js
@@ -27,10 +27,10 @@ export default function(objects) {
 
   var extractGeometryType = {
     GeometryCollection: function(o) { o.geometries.forEach(extractGeometry); },
-    LineString: function(o) { o.arcs = extractLine(o.coordinates); delete o.coordinates; },
-    MultiLineString: function(o) { o.arcs = o.coordinates.map(extractLine); delete o.coordinates; },
-    Polygon: function(o) { o.arcs = o.coordinates.map(extractRing); delete o.coordinates; },
-    MultiPolygon: function(o) { o.arcs = o.coordinates.map(extractMultiRing); delete o.coordinates; }
+    LineString: function(o) { o.arcs = extractLine(o.arcs); },
+    MultiLineString: function(o) { o.arcs = o.arcs.map(extractLine); },
+    Polygon: function(o) { o.arcs = o.arcs.map(extractRing); },
+    MultiPolygon: function(o) { o.arcs = o.arcs.map(extractMultiRing); }
   };
 
   function extractLine(line) {

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -31,9 +31,9 @@ function geomifyFeature(input) {
 
 function geomifyGeometry(input) {
   if (input == null) return {type: null};
-  var output = input.type === "GeometryCollection"
-      ? {type: "GeometryCollection", geometries: input.geometries.map(geomifyGeometry)}
-      : {type: input.type, coordinates: input.coordinates};
+  var output = input.type === "GeometryCollection" ? {type: "GeometryCollection", geometries: input.geometries.map(geomifyGeometry)}
+      : input.type === "Point" || input.type === "MultiPoint" ? {type: input.type, coordinates: input.coordinates}
+      : {type: input.type, arcs: input.coordinates}; // TODO Check for unknown types?
   if (input.bbox != null) output.bbox = input.bbox;
   return output;
 }

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -1,115 +1,39 @@
-// Given a hash of GeoJSON objects, replaces Features with geometry objects.
-// This is a destructive operation that modifies the input objects!
-export default function(objects) {
-  var key;
-  for (key in objects) objects[key] = geomifyObject(objects[key]);
-  return objects;
+// Given a hash of GeoJSON objects, returns a hash of GeoJSON geometry objects.
+// Any null input geometry objects are represented as {type: null} in the output.
+// Any feature.{id,properties,bbox} are transferred to the output geometry object.
+// Each output geometry object is a shallow copy of the input (e.g., properties, coordinates)!
+export default function(inputs) {
+  var outputs = {}, key;
+  for (key in inputs) outputs[key] = geomifyObject(inputs[key]);
+  return outputs;
 }
 
-function geomifyObject(object) {
-  return (object && geomifyObjectType.hasOwnProperty(object.type)
-      ? geomifyObjectType[object.type]
-      : geomifyGeometry)(object);
+function geomifyObject(input) {
+  return input == null ? {type: null}
+      : (input.type === "FeatureCollection" ? geomifyFeatureCollection
+      : input.type === "Feature" ? geomifyFeature
+      : geomifyGeometry)(input);
 }
 
-function geomifyFeature(feature) {
-  var geometry = feature.geometry;
-  if (geometry == null) {
-    feature.type = null;
-  } else {
-    geomifyGeometry(geometry);
-    feature.type = geometry.type;
-    if (geometry.geometries) feature.geometries = geometry.geometries;
-    else if (geometry.coordinates) feature.coordinates = geometry.coordinates;
-    if (geometry.bbox) feature.bbox = geometry.bbox;
-  }
-  delete feature.geometry;
-  return feature;
+function geomifyFeatureCollection(input) {
+  var output = {type: "GeometryCollection", geometries: input.features.map(geomifyFeature)};
+  if (input.bbox != null) output.bbox = input.bbox;
+  return output;
 }
 
-function geomifyGeometry(geometry) {
-  if (!geometry) return {type: null};
-  if (geomifyGeometryType.hasOwnProperty(geometry.type)) geomifyGeometryType[geometry.type](geometry);
-  return geometry;
+function geomifyFeature(input) {
+  var output = geomifyGeometry(input.geometry);
+  if (input.id != null) output.id = input.id;
+  if (input.bbox != null) output.bbox = input.bbox;
+  if (input.properties != null) output.properties = input.properties;
+  return output;
 }
 
-var geomifyObjectType = {
-  Feature: geomifyFeature,
-  FeatureCollection: function(collection) {
-    collection.type = "GeometryCollection";
-    collection.geometries = collection.features;
-    collection.features.forEach(geomifyFeature);
-    delete collection.features;
-    return collection;
-  }
-};
-
-var geomifyGeometryType = {
-  GeometryCollection: function(o) {
-    var geometries = o.geometries, i = -1, n = geometries.length;
-    while (++i < n) geometries[i] = geomifyGeometry(geometries[i]);
-  },
-  MultiPoint: function(o) {
-    if (!o.coordinates.length) {
-      o.type = null;
-      delete o.coordinates;
-    } else if (o.coordinates.length < 2) {
-      o.type = "Point";
-      o.coordinates = o.coordinates[0];
-    }
-  },
-  LineString: function(o) {
-    if (!o.coordinates.length) {
-      o.type = null;
-      delete o.coordinates;
-    }
-  },
-  MultiLineString: function(o) {
-    for (var lines = o.coordinates, i = 0, N = 0, n = lines.length; i < n; ++i) {
-      var line = lines[i];
-      if (line.length) lines[N++] = line;
-    }
-    if (!N) {
-      o.type = null;
-      delete o.coordinates;
-    } else if (N < 2) {
-      o.type = "LineString";
-      o.coordinates = lines[0];
-    } else {
-      o.coordinates.length = N;
-    }
-  },
-  Polygon: function(o) {
-    for (var rings = o.coordinates, i = 0, N = 0, n = rings.length; i < n; ++i) {
-      var ring = rings[i];
-      if (ring.length) rings[N++] = ring;
-    }
-    if (!N) {
-      o.type = null;
-      delete o.coordinates;
-    } else {
-      o.coordinates.length = N;
-    }
-  },
-  MultiPolygon: function(o) {
-    for (var polygons = o.coordinates, j = 0, M = 0, m = polygons.length; j < m; ++j) {
-      for (var rings = polygons[j], i = 0, N = 0, n = rings.length; i < n; ++i) {
-        var ring = rings[i];
-        if (ring.length) rings[N++] = ring;
-      }
-      if (N) {
-        rings.length = N;
-        polygons[M++] = rings;
-      }
-    }
-    if (!M) {
-      o.type = null;
-      delete o.coordinates;
-    } else if (M < 2) {
-      o.type = "Polygon";
-      o.coordinates = polygons[0];
-    } else {
-      polygons.length = M;
-    }
-  }
-};
+function geomifyGeometry(input) {
+  if (input == null) return {type: null};
+  var output = input.type === "GeometryCollection"
+      ? {type: "GeometryCollection", geometries: input.geometries.map(geomifyGeometry)}
+      : {type: input.type, coordinates: input.coordinates};
+  if (input.bbox != null) output.bbox = input.bbox;
+  return output;
+}

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -22,10 +22,10 @@ function geomifyFeatureCollection(input) {
 }
 
 function geomifyFeature(input) {
-  var output = geomifyGeometry(input.geometry);
+  var output = geomifyGeometry(input.geometry), key; // eslint-disable-line no-unused-vars
   if (input.id != null) output.id = input.id;
   if (input.bbox != null) output.bbox = input.bbox;
-  if (input.properties != null) output.properties = input.properties;
+  for (key in input.properties) { output.properties = input.properties; break; }
   return output;
 }
 

--- a/src/prequantize.js
+++ b/src/prequantize.js
@@ -13,7 +13,7 @@ export default function(objects, bbox, n) {
     ];
   }
 
-  function quantizeLine(input) {
+  function quantizePoints(input, m) {
     var i = 0,
         j = 1,
         n = input.length,
@@ -35,15 +35,17 @@ export default function(objects, bbox, n) {
       }
     }
 
-    if (j < 2) output[1] = output[0].slice(), j = 2; // must have 2+
     output.length = j;
+    while (j < m) j = output.push(output[0].slice());
     return output;
   }
 
+  function quantizeLine(input) {
+    return quantizePoints(input, 2);
+  }
+
   function quantizeRing(input) {
-    var output = quantizeLine(input);
-    while (output.length < 4) output.push(output[0].slice()); // must have 4+
-    return output;
+    return quantizePoints(input, 4);
   }
 
   function quantizePolygon(input) {

--- a/src/prequantize.js
+++ b/src/prequantize.js
@@ -36,7 +36,7 @@ export default function(objects, bbox, n) {
     }
 
     output.length = j;
-    while (j < m) j = output.push(output[0].slice());
+    while (j < m) j = output.push([output[0][0], output[0][1]]);
     return output;
   }
 

--- a/src/prequantize.js
+++ b/src/prequantize.js
@@ -14,25 +14,21 @@ export default function(objects, bbox, n) {
   }
 
   function quantizePoints(input, m) {
-    var i = 0,
-        j = 1,
+    var i = -1,
+        j = 0,
         n = input.length,
         output = new Array(n), // pessimistic
-        pi = output[0] = quantizePoint(input[0]),
-        px = pi[0],
-        py = pi[1],
+        pi,
+        px,
+        py,
         x,
         y;
 
     while (++i < n) {
-      pi = quantizePoint(input[i]);
-      x = pi[0];
-      y = pi[1];
-      if (x !== px || y !== py) { // skip coincident points
-        output[j++] = pi;
-        px = x;
-        py = y;
-      }
+      pi = input[i];
+      x = Math.round((pi[0] - x0) * kx);
+      y = Math.round((pi[1] - y0) * ky);
+      if (x !== px || y !== py) output[j++] = [px = x, py = y]; // non-coincident points
     }
 
     output.length = j;

--- a/src/prequantize.js
+++ b/src/prequantize.js
@@ -53,10 +53,10 @@ export default function(objects, bbox, n) {
     GeometryCollection: function(o) { o.geometries.forEach(quantizeGeometry); },
     Point: function(o) { o.coordinates = quantizePoint(o.coordinates); },
     MultiPoint: function(o) { o.coordinates = o.coordinates.map(quantizePoint); },
-    LineString: function(o) { o.coordinates = quantizeLine(o.coordinates); },
-    MultiLineString: function(o) { o.coordinates = o.coordinates.map(quantizeLine); },
-    Polygon: function(o) { o.coordinates = quantizePolygon(o.coordinates); },
-    MultiPolygon: function(o) { o.coordinates = o.coordinates.map(quantizePolygon); }
+    LineString: function(o) { o.arcs = quantizeLine(o.arcs); },
+    MultiLineString: function(o) { o.arcs = o.arcs.map(quantizeLine); },
+    Polygon: function(o) { o.arcs = quantizePolygon(o.arcs); },
+    MultiPolygon: function(o) { o.arcs = o.arcs.map(quantizePolygon); }
   };
 
   for (var key in objects) {

--- a/src/prequantize.js
+++ b/src/prequantize.js
@@ -7,10 +7,7 @@ export default function(objects, bbox, n) {
       ky = y1 - y0 ? (n - 1) / (y1 - y0) : 1;
 
   function quantizePoint(input) {
-    return [
-      Math.round((input[0] - x0) * kx),
-      Math.round((input[1] - y0) * ky)
-    ];
+    return [Math.round((input[0] - x0) * kx), Math.round((input[1] - y0) * ky)];
   }
 
   function quantizePoints(input, m) {

--- a/src/topology.js
+++ b/src/topology.js
@@ -11,7 +11,7 @@ import prequantize from "./prequantize";
 // Each object in the specified hash must be a GeoJSON object,
 // meaning FeatureCollection, a Feature or a geometry object.
 export default function(objects, quantization) {
-  var bbox = bounds(geometry(objects)),
+  var bbox = bounds(objects = geometry(objects)),
       transform = quantization > 0 && bbox && prequantize(objects, bbox, quantization),
       topology = dedup(cut(extract(objects))),
       coordinates = topology.coordinates,

--- a/src/topology.js
+++ b/src/topology.js
@@ -58,7 +58,7 @@ export default function(objects, quantization) {
 
   if (transform) {
     topology.transform = transform;
-    delta(topology);
+    topology.arcs = delta(topology.arcs);
   }
 
   return topology;

--- a/test/bounds-test.js
+++ b/test/bounds-test.js
@@ -6,7 +6,7 @@ tape("bounds computes the bounding box", function(test) {
   test.deepEqual(bounds({
     foo: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [0, 2], [0, 0]]
+      arcs: [[0, 0], [1, 0], [0, 2], [0, 0]]
     }
   }), [0, 0, 1, 2]);
   test.end();

--- a/test/cut-test.js
+++ b/test/cut-test.js
@@ -5,8 +5,8 @@ var tape = require("tape"),
 
 tape("cut exact duplicate lines ABC & ABC have no cuts", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abc2: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abc2: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -17,8 +17,8 @@ tape("cut exact duplicate lines ABC & ABC have no cuts", function(test) {
 
 tape("cut reversed duplicate lines ABC & CBA have no cuts", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -29,8 +29,8 @@ tape("cut reversed duplicate lines ABC & CBA have no cuts", function(test) {
 
 tape("cut exact duplicate rings ABCA & ABCA have no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    abca2: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    abca2: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -41,8 +41,8 @@ tape("cut exact duplicate rings ABCA & ABCA have no cuts", function(test) {
 
 tape("cut reversed duplicate rings ACBA & ABCA have no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    acba: {type: "Polygon", coordinates: [[[0, 0], [2, 0], [1, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    acba: {type: "Polygon", arcs: [[[0, 0], [2, 0], [1, 0], [0, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -53,8 +53,8 @@ tape("cut reversed duplicate rings ACBA & ABCA have no cuts", function(test) {
 
 tape("cut rotated duplicate rings BCAB & ABCA have no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    bcab: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [0, 0], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    bcab: {type: "Polygon", arcs: [[[1, 0], [2, 0], [0, 0], [1, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -65,8 +65,8 @@ tape("cut rotated duplicate rings BCAB & ABCA have no cuts", function(test) {
 
 tape("cut ring ABCA & line ABCA have no cuts", function(test) {
   var topology = cut(extract({
-    abcaLine: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [0, 0]]},
-    abcaPolygon: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    abcaLine: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [0, 0]]},
+    abcaPolygon: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
   }));
   test.deepEqual(topology.objects, {
     abcaLine: {type: "LineString", arcs: {0: 0, 1: 3}},
@@ -77,8 +77,8 @@ tape("cut ring ABCA & line ABCA have no cuts", function(test) {
 
 tape("cut ring BCAB & line ABCA have no cuts", function(test) {
   var topology = cut(extract({
-    abcaLine: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [0, 0]]},
-    bcabPolygon: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [0, 0], [1, 0]]]},
+    abcaLine: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [0, 0]]},
+    bcabPolygon: {type: "Polygon", arcs: [[[1, 0], [2, 0], [0, 0], [1, 0]]]},
   }));
   test.deepEqual(topology.objects, {
     abcaLine: {type: "LineString", arcs: {0: 0, 1: 3}},
@@ -90,8 +90,8 @@ tape("cut ring BCAB & line ABCA have no cuts", function(test) {
 
 tape("cut ring ABCA & line BCAB have no cuts", function(test) {
   var topology = cut(extract({
-    bcabLine: {type: "LineString", coordinates: [[1, 0], [2, 0], [0, 0], [1, 0]]},
-    abcaPolygon: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    bcabLine: {type: "LineString", arcs: [[1, 0], [2, 0], [0, 0], [1, 0]]},
+    abcaPolygon: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
   }));
   test.deepEqual(topology.objects, {
     bcabLine: {type: "LineString", arcs: {0: 0, 1: 3}},
@@ -102,8 +102,8 @@ tape("cut ring ABCA & line BCAB have no cuts", function(test) {
 
 tape("cut when an old arc ABC extends a new arc AB, ABC is cut into AB-BC", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -114,8 +114,8 @@ tape("cut when an old arc ABC extends a new arc AB, ABC is cut into AB-BC", func
 
 tape("cut when a reversed old arc CBA extends a new arc AB, CBA is cut into CB-BA", function(test) {
   var topology = cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]}
   }));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -126,8 +126,8 @@ tape("cut when a reversed old arc CBA extends a new arc AB, CBA is cut into CB-B
 
 tape("cut when a new arc ADE shares its start with an old arc ABC, there are no cuts", function(test) {
   var topology = cut(extract({
-    ade: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 1], [2, 1]]}
+    ade: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 1], [2, 1]]}
   }));
   test.deepEqual(topology.objects, {
     ade: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -138,7 +138,7 @@ tape("cut when a new arc ADE shares its start with an old arc ABC, there are no 
 
 tape("cut ring ABA has no cuts", function(test) {
   var topology = cut(extract({
-    aba: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 0]]]},
+    aba: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 0]]]},
   }));
   test.deepEqual(topology.objects, {
     aba: {type: "Polygon", arcs: [{0: 0, 1: 2}]}
@@ -148,7 +148,7 @@ tape("cut ring ABA has no cuts", function(test) {
 
 tape("cut ring AA has no cuts", function(test) {
   var topology = cut(extract({
-    aa: {type: "Polygon", coordinates: [[[0, 0], [0, 0]]]},
+    aa: {type: "Polygon", arcs: [[[0, 0], [0, 0]]]},
   }));
   test.deepEqual(topology.objects, {
     aa: {type: "Polygon", arcs: [{0: 0, 1: 1}]}
@@ -158,7 +158,7 @@ tape("cut ring AA has no cuts", function(test) {
 
 tape("cut degenerate ring A has no cuts", function(test) {
   var topology = cut(extract({
-    a: {type: "Polygon", coordinates: [[[0, 0]]]},
+    a: {type: "Polygon", arcs: [[[0, 0]]]},
   }));
   test.deepEqual(topology.objects, {
     a: {type: "Polygon", arcs: [{0: 0, 1: 0}]}
@@ -168,8 +168,8 @@ tape("cut degenerate ring A has no cuts", function(test) {
 
 tape("cut when a new line DEC shares its end with an old line ABC, there are no cuts", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dec: {type: "LineString", coordinates: [[0, 1], [1, 1], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dec: {type: "LineString", arcs: [[0, 1], [1, 1], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -180,8 +180,8 @@ tape("cut when a new line DEC shares its end with an old line ABC, there are no 
 
 tape("cut when a new line ABC extends an old line AB, ABC is cut into AB-BC", function(test) {
   var topology = cut(extract({
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     ab: {type: "LineString", arcs: {0: 0, 1: 1}},
@@ -192,8 +192,8 @@ tape("cut when a new line ABC extends an old line AB, ABC is cut into AB-BC", fu
 
 tape("cut when a new line ABC extends a reversed old line BA, ABC is cut into AB-BC", function(test) {
   var topology = cut(extract({
-    ba: {type: "LineString", coordinates: [[1, 0], [0, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    ba: {type: "LineString", arcs: [[1, 0], [0, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     ba: {type: "LineString", arcs: {0: 0, 1: 1}},
@@ -204,8 +204,8 @@ tape("cut when a new line ABC extends a reversed old line BA, ABC is cut into AB
 
 tape("cut when a new line starts BC in the middle of an old line ABC, ABC is cut into AB-BC", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    bc: {type: "LineString", coordinates: [[1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    bc: {type: "LineString", arcs: [[1, 0], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -216,8 +216,8 @@ tape("cut when a new line starts BC in the middle of an old line ABC, ABC is cut
 
 tape("cut when a new line BC starts in the middle of a reversed old line CBA, CBA is cut into CB-BA", function(test) {
   var topology = cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    bc: {type: "LineString", coordinates: [[1, 0], [2, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    bc: {type: "LineString", arcs: [[1, 0], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -228,8 +228,8 @@ tape("cut when a new line BC starts in the middle of a reversed old line CBA, CB
 
 tape("cut when a new line ABD deviates from an old line ABC, ABD is cut into AB-BD and ABC is cut into AB-BC", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abd: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abd: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -240,8 +240,8 @@ tape("cut when a new line ABD deviates from an old line ABC, ABD is cut into AB-
 
 tape("cut when a new line ABD deviates from a reversed old line CBA, CBA is cut into CB-BA and ABD is cut into AB-BD", function(test) {
   var topology = cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    abd: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    abd: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0]]}
   }));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -252,8 +252,8 @@ tape("cut when a new line ABD deviates from a reversed old line CBA, CBA is cut 
 
 tape("cut when a new line DBC merges into an old line ABC, DBC is cut into DB-BC and ABC is cut into AB-BC", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dbc: {type: "LineString", coordinates: [[3, 0], [1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dbc: {type: "LineString", arcs: [[3, 0], [1, 0], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -264,8 +264,8 @@ tape("cut when a new line DBC merges into an old line ABC, DBC is cut into DB-BC
 
 tape("cut when a new line DBC merges into a reversed old line CBA, DBC is cut into DB-BC and CBA is cut into CB-BA", function(test) {
   var topology = cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    dbc: {type: "LineString", coordinates: [[3, 0], [1, 0], [2, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    dbc: {type: "LineString", arcs: [[3, 0], [1, 0], [2, 0]]}
   }));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -276,8 +276,8 @@ tape("cut when a new line DBC merges into a reversed old line CBA, DBC is cut in
 
 tape("cut when a new line DBE shares a single midpoint with an old line ABC, DBE is cut into DB-BE and ABC is cut into AB-BC", function(test) {
   var topology = cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dbe: {type: "LineString", coordinates: [[0, 1], [1, 0], [2, 1]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dbe: {type: "LineString", arcs: [[0, 1], [1, 0], [2, 1]]}
   }));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -288,8 +288,8 @@ tape("cut when a new line DBE shares a single midpoint with an old line ABC, DBE
 
 tape("cut when a new line ABDE skips a point with an old line ABCDE, ABDE is cut into AB-BD-DE and ABCDE is cut into AB-BCD-DE", function(test) {
   var topology = cut(extract({
-    abcde: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]]},
-    abde: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0], [4, 0]]}
+    abcde: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]]},
+    abde: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0], [4, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abcde: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 3, next: {0: 3, 1: 4}}}},
@@ -300,8 +300,8 @@ tape("cut when a new line ABDE skips a point with an old line ABCDE, ABDE is cut
 
 tape("cut when a new line ABDE skips a point with a reversed old line EDCBA, ABDE is cut into AB-BD-DE and EDCBA is cut into ED-DCB-BA", function(test) {
   var topology = cut(extract({
-    edcba: {type: "LineString", coordinates: [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]]},
-    abde: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0], [4, 0]]}
+    edcba: {type: "LineString", arcs: [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]]},
+    abde: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0], [4, 0]]}
   }));
   test.deepEqual(topology.objects, {
     edcba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 3, next: {0: 3, 1: 4}}}},
@@ -312,7 +312,7 @@ tape("cut when a new line ABDE skips a point with a reversed old line EDCBA, ABD
 
 tape("cut when a line ABCDBE self-intersects with its middle, it is not cut", function(test) {
   var topology = cut(extract({
-    abcdbe: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]}
+    abcdbe: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abcdbe: {type: "LineString", arcs: {0: 0, 1: 5}}
@@ -322,7 +322,7 @@ tape("cut when a line ABCDBE self-intersects with its middle, it is not cut", fu
 
 tape("cut when a line ABACD self-intersects with its start, it is cut into ABA-ACD", function(test) {
   var topology = cut(extract({
-    abacd: {type: "LineString", coordinates: [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]]}
+    abacd: {type: "LineString", arcs: [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abacd: {type: "LineString", arcs: {0: 0, 1: 2, next: {0: 2, 1: 4}}}
@@ -332,7 +332,7 @@ tape("cut when a line ABACD self-intersects with its start, it is cut into ABA-A
 
 tape("cut when a line ABDCD self-intersects with its end, it is cut into ABD-DCD", function(test) {
   var topology = cut(extract({
-    abdcd: {type: "LineString", coordinates: [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]]}
+    abdcd: {type: "LineString", arcs: [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abdcd: {type: "LineString", arcs: {0: 0, 1: 2, next: {0: 2, 1: 4}}}
@@ -342,8 +342,8 @@ tape("cut when a line ABDCD self-intersects with its end, it is cut into ABD-DCD
 
 tape("cut when an old line ABCDBE self-intersects and shares a point B, ABCDBE is cut into AB-BCDB-BE and FBG is cut into FB-BG", function(test) {
   var topology = cut(extract({
-    abcdbe: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]},
-    fbg: {type: "LineString", coordinates: [[0, 1], [1, 0], [2, 1]]}
+    abcdbe: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]},
+    fbg: {type: "LineString", arcs: [[0, 1], [1, 0], [2, 1]]}
   }));
   test.deepEqual(topology.objects, {
     abcdbe: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 4, next: {0: 4, 1: 5}}}},
@@ -354,7 +354,7 @@ tape("cut when an old line ABCDBE self-intersects and shares a point B, ABCDBE i
 
 tape("cut when a line ABCA is closed, there are no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "LineString", coordinates: [[0, 0], [1, 0], [0, 1], [0, 0]]}
+    abca: {type: "LineString", arcs: [[0, 0], [1, 0], [0, 1], [0, 0]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "LineString", arcs: {0: 0, 1: 3}}
@@ -364,7 +364,7 @@ tape("cut when a line ABCA is closed, there are no cuts", function(test) {
 
 tape("cut when a ring ABCA is closed, there are no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]}
@@ -374,8 +374,8 @@ tape("cut when a ring ABCA is closed, there are no cuts", function(test) {
 
 tape("cut exact duplicate rings ABCA & ABCA have no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    abca2: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    abca2: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -386,8 +386,8 @@ tape("cut exact duplicate rings ABCA & ABCA have no cuts", function(test) {
 
 tape("cut reversed duplicate rings ABCA & ACBA have no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    acba: {type: "Polygon", coordinates: [[[0, 0], [0, 1], [1, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    acba: {type: "Polygon", arcs: [[[0, 0], [0, 1], [1, 0], [0, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -398,8 +398,8 @@ tape("cut reversed duplicate rings ABCA & ACBA have no cuts", function(test) {
 
 tape("cut coincident rings ABCA & BCAB have no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    bcab: {type: "Polygon", coordinates: [[[1, 0], [0, 1], [0, 0], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    bcab: {type: "Polygon", arcs: [[[1, 0], [0, 1], [0, 0], [1, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -410,8 +410,8 @@ tape("cut coincident rings ABCA & BCAB have no cuts", function(test) {
 
 tape("cut coincident rings ABCA & BACB have no cuts", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    bacb: {type: "Polygon", coordinates: [[[1, 0], [0, 0], [0, 1], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    bacb: {type: "Polygon", arcs: [[[1, 0], [0, 0], [0, 1], [1, 0]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -422,9 +422,9 @@ tape("cut coincident rings ABCA & BACB have no cuts", function(test) {
 
 tape("cut coincident rings ABCDA, EFAE & GHCG are cut into ABC-CDA, EFAE and GHCG", function(test) {
   var topology = cut(extract({
-    abcda: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
-    efae: {type: "Polygon", coordinates: [[[0, -1], [1, -1], [0, 0], [0, -1]]]},
-    ghcg: {type: "Polygon", coordinates: [[[0, 2], [1, 2], [1, 1], [0, 2]]]}
+    abcda: {type: "Polygon", arcs: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+    efae: {type: "Polygon", arcs: [[[0, -1], [1, -1], [0, 0], [0, -1]]]},
+    ghcg: {type: "Polygon", arcs: [[[0, 2], [1, 2], [1, 1], [0, 2]]]}
   }));
   test.deepEqual(topology.objects, {
     abcda: {type: "Polygon", arcs: [{0: 0, 1: 2, next: {0: 2, 1: 4}}]},
@@ -436,8 +436,8 @@ tape("cut coincident rings ABCDA, EFAE & GHCG are cut into ABC-CDA, EFAE and GHC
 
 tape("cut coincident rings ABCA & DBED have no cuts, but are rotated to share B", function(test) {
   var topology = cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    dbed: {type: "Polygon", coordinates: [[[2, 1], [1, 0], [2, 2], [2, 1]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    dbed: {type: "Polygon", arcs: [[[2, 1], [1, 0], [2, 2], [2, 1]]]}
   }));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -450,8 +450,8 @@ tape("cut coincident rings ABCA & DBED have no cuts, but are rotated to share B"
 
 tape("cut overlapping rings ABCDA and BEFCB are cut into BC-CDAB and BEFC-CB", function(test) {
   var topology = cut(extract({
-    abcda: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}, // rotated to BCDAB, cut BC-CDAB
-    befcb: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]},
+    abcda: {type: "Polygon", arcs: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}, // rotated to BCDAB, cut BC-CDAB
+    befcb: {type: "Polygon", arcs: [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]},
   }));
   test.deepEqual(topology.objects, {
     abcda: {type: "Polygon", arcs: [{0: 0, 1: 1, next: {0: 1, 1: 4}}]},

--- a/test/dedup-test.js
+++ b/test/dedup-test.js
@@ -6,8 +6,8 @@ var tape = require("tape"),
 
 tape("dedup exact duplicate lines ABC & ABC share an arc", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abc2: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abc2: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -18,8 +18,8 @@ tape("dedup exact duplicate lines ABC & ABC share an arc", function(test) {
 
 tape("dedup reversed duplicate lines ABC & CBA share an arc", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -30,8 +30,8 @@ tape("dedup reversed duplicate lines ABC & CBA share an arc", function(test) {
 
 tape("dedup exact duplicate rings ABCA & ABCA share an arc", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    abca2: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    abca2: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -42,8 +42,8 @@ tape("dedup exact duplicate rings ABCA & ABCA share an arc", function(test) {
 
 tape("dedup reversed duplicate rings ACBA & ABCA share an arc", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    acba: {type: "Polygon", coordinates: [[[0, 0], [2, 0], [1, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    acba: {type: "Polygon", arcs: [[[0, 0], [2, 0], [1, 0], [0, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -54,8 +54,8 @@ tape("dedup reversed duplicate rings ACBA & ABCA share an arc", function(test) {
 
 tape("dedup rotated duplicate rings BCAB & ABCA share an arc", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    bcab: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [0, 0], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    bcab: {type: "Polygon", arcs: [[[1, 0], [2, 0], [0, 0], [1, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -66,8 +66,8 @@ tape("dedup rotated duplicate rings BCAB & ABCA share an arc", function(test) {
 
 tape("dedup ring ABCA & line ABCA have no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abcaLine: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [0, 0]]},
-    abcaPolygon: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    abcaLine: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [0, 0]]},
+    abcaPolygon: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
   })));
   test.deepEqual(topology.objects, {
     abcaLine: {type: "LineString", arcs: {0: 0, 1: 3}},
@@ -78,8 +78,8 @@ tape("dedup ring ABCA & line ABCA have no cuts", function(test) {
 
 tape("dedup ring BCAB & line ABCA have no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abcaLine: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [0, 0]]},
-    bcabPolygon: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [0, 0], [1, 0]]]},
+    abcaLine: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [0, 0]]},
+    bcabPolygon: {type: "Polygon", arcs: [[[1, 0], [2, 0], [0, 0], [1, 0]]]},
   })));
   test.deepEqual(topology.objects, {
     abcaLine: {type: "LineString", arcs: {0: 0, 1: 3}},
@@ -91,8 +91,8 @@ tape("dedup ring BCAB & line ABCA have no cuts", function(test) {
 
 tape("dedup ring ABCA & line BCAB have no cuts", function(test) {
   var topology = dedup(cut(extract({
-    bcabLine: {type: "LineString", coordinates: [[1, 0], [2, 0], [0, 0], [1, 0]]},
-    abcaPolygon: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}, // rotated to BCAB
+    bcabLine: {type: "LineString", arcs: [[1, 0], [2, 0], [0, 0], [1, 0]]},
+    abcaPolygon: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}, // rotated to BCAB
   })));
   test.deepEqual(topology.objects, {
     bcabLine: {type: "LineString", arcs: {0: 0, 1: 3}},
@@ -103,8 +103,8 @@ tape("dedup ring ABCA & line BCAB have no cuts", function(test) {
 
 tape("dedup when an old arc ABC extends a new arc AB, ABC is cut into AB-BC", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -115,8 +115,8 @@ tape("dedup when an old arc ABC extends a new arc AB, ABC is cut into AB-BC", fu
 
 tape("dedup when a reversed old arc CBA extends a new arc AB, CBA is cut into CB-BA", function(test) {
   var topology = dedup(cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]}
   })));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -127,8 +127,8 @@ tape("dedup when a reversed old arc CBA extends a new arc AB, CBA is cut into CB
 
 tape("dedup when a new arc ADE shares its start with an old arc ABC, there are no cuts", function(test) {
   var topology = dedup(cut(extract({
-    ade: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 1], [2, 1]]}
+    ade: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 1], [2, 1]]}
   })));
   test.deepEqual(topology.objects, {
     ade: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -139,7 +139,7 @@ tape("dedup when a new arc ADE shares its start with an old arc ABC, there are n
 
 tape("dedup ring ABA has no cuts", function(test) {
   var topology = dedup(cut(extract({
-    aba: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 0]]]},
+    aba: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 0]]]},
   })));
   test.deepEqual(topology.objects, {
     aba: {type: "Polygon", arcs: [{0: 0, 1: 2}]}
@@ -149,7 +149,7 @@ tape("dedup ring ABA has no cuts", function(test) {
 
 tape("dedup ring AA has no cuts", function(test) {
   var topology = dedup(cut(extract({
-    aa: {type: "Polygon", coordinates: [[[0, 0], [0, 0]]]},
+    aa: {type: "Polygon", arcs: [[[0, 0], [0, 0]]]},
   })));
   test.deepEqual(topology.objects, {
     aa: {type: "Polygon", arcs: [{0: 0, 1: 1}]}
@@ -159,7 +159,7 @@ tape("dedup ring AA has no cuts", function(test) {
 
 tape("dedup degenerate ring A has no cuts", function(test) {
   var topology = dedup(cut(extract({
-    a: {type: "Polygon", coordinates: [[[0, 0]]]},
+    a: {type: "Polygon", arcs: [[[0, 0]]]},
   })));
   test.deepEqual(topology.objects, {
     a: {type: "Polygon", arcs: [{0: 0, 1: 0}]}
@@ -169,8 +169,8 @@ tape("dedup degenerate ring A has no cuts", function(test) {
 
 tape("dedup when a new line DEC shares its end with an old line ABC, there are no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dec: {type: "LineString", coordinates: [[0, 1], [1, 1], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dec: {type: "LineString", arcs: [[0, 1], [1, 1], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 2}},
@@ -181,8 +181,8 @@ tape("dedup when a new line DEC shares its end with an old line ABC, there are n
 
 tape("dedup when a new line ABC extends an old line AB, ABC is cut into AB-BC", function(test) {
   var topology = dedup(cut(extract({
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     ab: {type: "LineString", arcs: {0: 0, 1: 1}},
@@ -193,8 +193,8 @@ tape("dedup when a new line ABC extends an old line AB, ABC is cut into AB-BC", 
 
 tape("dedup when a new line ABC extends a reversed old line BA, ABC is cut into AB-BC", function(test) {
   var topology = dedup(cut(extract({
-    ba: {type: "LineString", coordinates: [[1, 0], [0, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    ba: {type: "LineString", arcs: [[1, 0], [0, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     ba: {type: "LineString", arcs: {0: 0, 1: 1}},
@@ -205,8 +205,8 @@ tape("dedup when a new line ABC extends a reversed old line BA, ABC is cut into 
 
 tape("dedup when a new line starts BC in the middle of an old line ABC, ABC is cut into AB-BC", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    bc: {type: "LineString", coordinates: [[1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    bc: {type: "LineString", arcs: [[1, 0], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -217,8 +217,8 @@ tape("dedup when a new line starts BC in the middle of an old line ABC, ABC is c
 
 tape("dedup when a new line BC starts in the middle of a reversed old line CBA, CBA is cut into CB-BA", function(test) {
   var topology = dedup(cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    bc: {type: "LineString", coordinates: [[1, 0], [2, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    bc: {type: "LineString", arcs: [[1, 0], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -229,8 +229,8 @@ tape("dedup when a new line BC starts in the middle of a reversed old line CBA, 
 
 tape("dedup when a new line ABD deviates from an old line ABC, ABD is cut into AB-BD and ABC is cut into AB-BC", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abd: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abd: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -241,8 +241,8 @@ tape("dedup when a new line ABD deviates from an old line ABC, ABD is cut into A
 
 tape("dedup when a new line ABD deviates from a reversed old line CBA, CBA is cut into CB-BA and ABD is cut into AB-BD", function(test) {
   var topology = dedup(cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    abd: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    abd: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0]]}
   })));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -253,8 +253,8 @@ tape("dedup when a new line ABD deviates from a reversed old line CBA, CBA is cu
 
 tape("dedup when a new line DBC merges into an old line ABC, DBC is cut into DB-BC and ABC is cut into AB-BC", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dbc: {type: "LineString", coordinates: [[3, 0], [1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dbc: {type: "LineString", arcs: [[3, 0], [1, 0], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -265,8 +265,8 @@ tape("dedup when a new line DBC merges into an old line ABC, DBC is cut into DB-
 
 tape("dedup when a new line DBC merges into a reversed old line CBA, DBC is cut into DB-BC and CBA is cut into CB-BA", function(test) {
   var topology = dedup(cut(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    dbc: {type: "LineString", coordinates: [[3, 0], [1, 0], [2, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    dbc: {type: "LineString", arcs: [[3, 0], [1, 0], [2, 0]]}
   })));
   test.deepEqual(topology.objects, {
     cba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -277,8 +277,8 @@ tape("dedup when a new line DBC merges into a reversed old line CBA, DBC is cut 
 
 tape("dedup when a new line DBE shares a single midpoint with an old line ABC, DBE is cut into DB-BE and ABC is cut into AB-BC", function(test) {
   var topology = dedup(cut(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dbe: {type: "LineString", coordinates: [[0, 1], [1, 0], [2, 1]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dbe: {type: "LineString", arcs: [[0, 1], [1, 0], [2, 1]]}
   })));
   test.deepEqual(topology.objects, {
     abc: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 2}}},
@@ -289,8 +289,8 @@ tape("dedup when a new line DBE shares a single midpoint with an old line ABC, D
 
 tape("dedup when a new line ABDE skips a point with an old line ABCDE, ABDE is cut into AB-BD-DE and ABCDE is cut into AB-BCD-DE", function(test) {
   var topology = dedup(cut(extract({
-    abcde: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]]},
-    abde: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0], [4, 0]]}
+    abcde: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]]},
+    abde: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0], [4, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abcde: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 3, next: {0: 3, 1: 4}}}},
@@ -301,8 +301,8 @@ tape("dedup when a new line ABDE skips a point with an old line ABCDE, ABDE is c
 
 tape("dedup when a new line ABDE skips a point with a reversed old line EDCBA, ABDE is cut into AB-BD-DE and EDCBA is cut into ED-DCB-BA", function(test) {
   var topology = dedup(cut(extract({
-    edcba: {type: "LineString", coordinates: [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]]},
-    abde: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0], [4, 0]]}
+    edcba: {type: "LineString", arcs: [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]]},
+    abde: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0], [4, 0]]}
   })));
   test.deepEqual(topology.objects, {
     edcba: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 3, next: {0: 3, 1: 4}}}},
@@ -313,7 +313,7 @@ tape("dedup when a new line ABDE skips a point with a reversed old line EDCBA, A
 
 tape("dedup when a line ABCDBE self-intersects with its middle, it is not cut", function(test) {
   var topology = dedup(cut(extract({
-    abcdbe: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]}
+    abcdbe: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abcdbe: {type: "LineString", arcs: {0: 0, 1: 5}}
@@ -323,7 +323,7 @@ tape("dedup when a line ABCDBE self-intersects with its middle, it is not cut", 
 
 tape("dedup when a line ABACD self-intersects with its start, it is cut into ABA-ACD", function(test) {
   var topology = dedup(cut(extract({
-    abacd: {type: "LineString", coordinates: [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]]}
+    abacd: {type: "LineString", arcs: [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abacd: {type: "LineString", arcs: {0: 0, 1: 2, next: {0: 2, 1: 4}}}
@@ -333,7 +333,7 @@ tape("dedup when a line ABACD self-intersects with its start, it is cut into ABA
 
 tape("dedup when a line ABDCD self-intersects with its end, it is cut into ABD-DCD", function(test) {
   var topology = dedup(cut(extract({
-    abdcd: {type: "LineString", coordinates: [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]]}
+    abdcd: {type: "LineString", arcs: [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abdcd: {type: "LineString", arcs: {0: 0, 1: 2, next: {0: 2, 1: 4}}}
@@ -343,8 +343,8 @@ tape("dedup when a line ABDCD self-intersects with its end, it is cut into ABD-D
 
 tape("dedup when an old line ABCDBE self-intersects and shares a point B, ABCDBE is cut into AB-BCDB-BE and FBG is cut into FB-BG", function(test) {
   var topology = dedup(cut(extract({
-    abcdbe: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]},
-    fbg: {type: "LineString", coordinates: [[0, 1], [1, 0], [2, 1]]}
+    abcdbe: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]},
+    fbg: {type: "LineString", arcs: [[0, 1], [1, 0], [2, 1]]}
   })));
   test.deepEqual(topology.objects, {
     abcdbe: {type: "LineString", arcs: {0: 0, 1: 1, next: {0: 1, 1: 4, next: {0: 4, 1: 5}}}},
@@ -355,7 +355,7 @@ tape("dedup when an old line ABCDBE self-intersects and shares a point B, ABCDBE
 
 tape("dedup when a line ABCA is closed, there are no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "LineString", coordinates: [[0, 0], [1, 0], [0, 1], [0, 0]]}
+    abca: {type: "LineString", arcs: [[0, 0], [1, 0], [0, 1], [0, 0]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "LineString", arcs: {0: 0, 1: 3}}
@@ -365,7 +365,7 @@ tape("dedup when a line ABCA is closed, there are no cuts", function(test) {
 
 tape("dedup when a ring ABCA is closed, there are no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]}
@@ -375,8 +375,8 @@ tape("dedup when a ring ABCA is closed, there are no cuts", function(test) {
 
 tape("dedup exact duplicate rings ABCA & ABCA have no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    abca2: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    abca2: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -387,8 +387,8 @@ tape("dedup exact duplicate rings ABCA & ABCA have no cuts", function(test) {
 
 tape("dedup reversed duplicate rings ABCA & ACBA have no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    acba: {type: "Polygon", coordinates: [[[0, 0], [0, 1], [1, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    acba: {type: "Polygon", arcs: [[[0, 0], [0, 1], [1, 0], [0, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -399,8 +399,8 @@ tape("dedup reversed duplicate rings ABCA & ACBA have no cuts", function(test) {
 
 tape("dedup coincident rings ABCA & BCAB have no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    bcab: {type: "Polygon", coordinates: [[[1, 0], [0, 1], [0, 0], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    bcab: {type: "Polygon", arcs: [[[1, 0], [0, 1], [0, 0], [1, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -411,8 +411,8 @@ tape("dedup coincident rings ABCA & BCAB have no cuts", function(test) {
 
 tape("dedup coincident reversed rings ABCA & BACB have no cuts", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    bacb: {type: "Polygon", coordinates: [[[1, 0], [0, 0], [0, 1], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    bacb: {type: "Polygon", arcs: [[[1, 0], [0, 0], [0, 1], [1, 0]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -423,9 +423,9 @@ tape("dedup coincident reversed rings ABCA & BACB have no cuts", function(test) 
 
 tape("dedup coincident rings ABCDA, EFAE & GHCG are cut into ABC-CDA, EFAE and GHCG", function(test) {
   var topology = dedup(cut(extract({
-    abcda: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
-    efae: {type: "Polygon", coordinates: [[[0, -1], [1, -1], [0, 0], [0, -1]]]},
-    ghcg: {type: "Polygon", coordinates: [[[0, 2], [1, 2], [1, 1], [0, 2]]]}
+    abcda: {type: "Polygon", arcs: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+    efae: {type: "Polygon", arcs: [[[0, -1], [1, -1], [0, 0], [0, -1]]]},
+    ghcg: {type: "Polygon", arcs: [[[0, 2], [1, 2], [1, 1], [0, 2]]]}
   })));
   test.deepEqual(topology.objects, {
     abcda: {type: "Polygon", arcs: [{0: 0, 1: 2, next: {0: 2, 1: 4}}]},
@@ -437,8 +437,8 @@ tape("dedup coincident rings ABCDA, EFAE & GHCG are cut into ABC-CDA, EFAE and G
 
 tape("dedup coincident rings ABCA & DBED have no cuts, but are rotated to share B", function(test) {
   var topology = dedup(cut(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    dbed: {type: "Polygon", coordinates: [[[2, 1], [1, 0], [2, 2], [2, 1]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    dbed: {type: "Polygon", arcs: [[[2, 1], [1, 0], [2, 2], [2, 1]]]}
   })));
   test.deepEqual(topology.objects, {
     abca: {type: "Polygon", arcs: [{0: 0, 1: 3}]},
@@ -451,8 +451,8 @@ tape("dedup coincident rings ABCA & DBED have no cuts, but are rotated to share 
 
 tape("dedup overlapping rings ABCDA and BEFCB are cut into BC-CDAB and BEFC-CB", function(test) {
   var topology = dedup(cut(extract({
-    abcda: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}, // rotated to BCDAB, cut BC-CDAB
-    befcb: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]},
+    abcda: {type: "Polygon", arcs: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}, // rotated to BCDAB, cut BC-CDAB
+    befcb: {type: "Polygon", arcs: [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]},
   })));
   test.deepEqual(topology.objects, {
     abcda: {type: "Polygon", arcs: [{0: 0, 1: 1, next: {0: 1, 1: 4}}]},

--- a/test/delta-test.js
+++ b/test/delta-test.js
@@ -3,28 +3,28 @@ var tape = require("tape"),
     delta = internals.delta;
 
 tape("delta converts arcs to delta encoding", function(test) {
-  test.deepEqual(delta({
-    type: "Topology",
-    arcs: [
-      [[0, 0], [9999, 0], [0, 9999], [0, 0]]
-    ],
-    objects: {}
-  }).arcs, [
+  test.deepEqual(delta([
+    [[0, 0], [9999, 0], [0, 9999], [0, 0]]
+  ]), [
     [[0, 0], [9999, 0], [-9999, 9999], [0, -9999]]
   ]);
   test.end();
 });
 
-tape("delta does not skip coincident points", function(test) {
-  test.deepEqual(delta({
-    type: "Topology",
-    arcs: [
-      [[0, 0], [9999, 0], [9999, 0], [0, 9999], [0, 0]]
-    ],
-    objects: {}
-  }).arcs, [
-    [[0, 0], [9999, 0], [0, 0], [-9999, 9999], [0, -9999]]
+tape("delta skips coincident points", function(test) {
+  test.deepEqual(delta([
+    [[0, 0], [9999, 0], [9999, 0], [0, 9999], [0, 0]]
+  ]), [
+    [[0, 0], [9999, 0], [-9999, 9999], [0, -9999]]
   ]);
   test.end();
 });
 
+tape("delta preserves at least two positions", function(test) {
+  test.deepEqual(delta([
+    [[12345, 12345], [12345, 12345], [12345, 12345], [12345, 12345]]
+  ]), [
+    [[12345, 12345], [0, 0]]
+  ]);
+  test.end();
+});

--- a/test/extract-test.js
+++ b/test/extract-test.js
@@ -6,11 +6,11 @@ tape("extract copies coordinates sequentially into a buffer", function(test) {
   var topology = extract({
     foo: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [2, 0]]
+      arcs: [[0, 0], [1, 0], [2, 0]]
     },
     bar: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [2, 0]]
+      arcs: [[0, 0], [1, 0], [2, 0]]
     }
   });
   test.deepEqual(topology.coordinates, [[0, 0], [1, 0], [2, 0], [0, 0], [1, 0], [2, 0]]);
@@ -21,16 +21,16 @@ tape("extract does not copy point geometries into the coordinate buffer", functi
   var topology = extract({
     foo: {
       type: "Point",
-      coordinates: [0, 0]
+      arcs: [0, 0]
     },
     bar: {
       type: "MultiPoint",
-      coordinates: [[0, 0], [1, 0], [2, 0]]
+      arcs: [[0, 0], [1, 0], [2, 0]]
     }
   });
   test.deepEqual(topology.coordinates, []);
-  test.deepEqual(topology.objects.foo.coordinates, [0, 0]);
-  test.deepEqual(topology.objects.bar.coordinates, [[0, 0], [1, 0], [2, 0]]);
+  test.deepEqual(topology.objects.foo.arcs, [0, 0]);
+  test.deepEqual(topology.objects.bar.arcs, [[0, 0], [1, 0], [2, 0]]);
   test.end();
 });
 
@@ -38,7 +38,7 @@ tape("extract includes closing coordinates in polygons", function(test) {
   var topology = extract({
     foo: {
       type: "Polygon",
-      coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
+      arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
     }
   });
   test.deepEqual(topology.coordinates, [[0, 0], [1, 0], [2, 0], [0, 0]]);
@@ -49,11 +49,11 @@ tape("extract represents lines as contiguous slices of the coordinate buffer", f
   var topology = extract({
     foo: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [2, 0]]
+      arcs: [[0, 0], [1, 0], [2, 0]]
     },
     bar: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [2, 0]]
+      arcs: [[0, 0], [1, 0], [2, 0]]
     }
   });
   test.deepEqual(topology.objects, {
@@ -73,11 +73,11 @@ tape("extract represents rings as contiguous slices of the coordinate buffer", f
   var topology = extract({
     foo: {
       type: "Polygon",
-      coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
+      arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
     },
     bar: {
       type: "Polygon",
-      coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
+      arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
     }
   });
   test.deepEqual(topology.objects, {
@@ -97,15 +97,15 @@ tape("extract exposes the constructed lines and rings in the order of constructi
   var topology = extract({
     line: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [2, 0]]
+      arcs: [[0, 0], [1, 0], [2, 0]]
     },
     multiline: {
       type: "MultiLineString",
-      coordinates: [[[0, 0], [1, 0], [2, 0]]]
+      arcs: [[[0, 0], [1, 0], [2, 0]]]
     },
     polygon: {
       type: "Polygon",
-      coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
+      arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]
     }
   });
   test.deepEqual(topology.lines, [
@@ -126,7 +126,7 @@ tape("extract supports nested geometry collections", function(test) {
         type: "GeometryCollection",
         geometries: [{
           type: "LineString",
-          coordinates: [[0, 0], [0, 1]]
+          arcs: [[0, 0], [0, 1]]
         }]
       }]
     }

--- a/test/geometry-test.js
+++ b/test/geometry-test.js
@@ -130,7 +130,7 @@ tape("geometry preserves id", function(test) {
   test.end();
 });
 
-tape("geometry preserves properties", function(test) {
+tape("geometry preserves properties if non-empty", function(test) {
   test.deepEqual(geometry({
     foo: {
       properties: {
@@ -171,7 +171,7 @@ tape("geometry applies a shallow copy for properties", function(test) {
   test.end();
 });
 
-tape("geometry does not delete empty properties", function(test) {
+tape("geometry deletes empty properties", function(test) {
   test.deepEqual(geometry({
     foo: {
       properties: {},
@@ -183,7 +183,6 @@ tape("geometry does not delete empty properties", function(test) {
     }
   }), {
     foo: {
-      properties: {},
       type: "LineString",
       arcs: [[0, 0]]
     }

--- a/test/geometry-test.js
+++ b/test/geometry-test.js
@@ -14,7 +14,7 @@ tape("geometry replaces LineString Feature with LineString Geometry", function(t
   }), {
     foo: {
       type: "LineString",
-      coordinates: [[0, 0]]
+      arcs: [[0, 0]]
     }
   });
   test.end();
@@ -37,7 +37,7 @@ tape("geometry replaces GeometryCollection Feature with GeometryCollection", fun
       type: "GeometryCollection",
       geometries: [{
         type: "LineString",
-        coordinates: [[0, 0]]
+        arcs: [[0, 0]]
       }]
     }
   });
@@ -61,7 +61,7 @@ tape("geometry replaces FeatureCollection with GeometryCollection", function(tes
       type: "GeometryCollection",
       geometries: [{
         type: "LineString",
-        coordinates: [[0, 0]]
+        arcs: [[0, 0]]
       }]
     }
   });
@@ -124,7 +124,7 @@ tape("geometry preserves id", function(test) {
     foo: {
       id: "foo",
       type: "LineString",
-      coordinates: [[0, 0]]
+      arcs: [[0, 0]]
     }
   });
   test.end();
@@ -148,7 +148,7 @@ tape("geometry preserves properties", function(test) {
         "foo": 42
       },
       type: "LineString",
-      coordinates: [[0, 0]]
+      arcs: [[0, 0]]
     }
   });
   test.end();
@@ -185,7 +185,7 @@ tape("geometry does not delete empty properties", function(test) {
     foo: {
       properties: {},
       type: "LineString",
-      coordinates: [[0, 0]]
+      arcs: [[0, 0]]
     }
   });
   test.end();
@@ -230,7 +230,7 @@ tape("geometry does not convert singular multilines to lines", function(test) {
   }), {
     foo: {
       type: "MultiLineString",
-      coordinates: [[[0, 0], [0, 1]]]
+      arcs: [[[0, 0], [0, 1]]]
     }
   });
   test.end();
@@ -245,7 +245,7 @@ tape("geometry does not convert empty lines to null", function(test) {
   }), {
     foo: {
       type: "LineString",
-      coordinates: []
+      arcs: []
     }
   });
   test.end();
@@ -264,11 +264,11 @@ tape("geometry does not convert empty multilines to null", function(test) {
   }), {
     foo: {
       type: "MultiLineString",
-      coordinates: []
+      arcs: []
     },
     bar: {
       type: "MultiLineString",
-      coordinates: [[]]
+      arcs: [[]]
     }
   });
   test.end();
@@ -283,7 +283,7 @@ tape("geometry does not strip empty rings in polygons", function(test) {
   }), {
     foo: {
       type: "Polygon",
-      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]], []]
+      arcs: [[[0, 0], [1, 0], [1, 1], [0, 0]], []]
     }
   });
   test.end();
@@ -298,7 +298,7 @@ tape("geometry does not strip empty lines in multilines", function(test) {
   }), {
     foo: {
       type: "MultiLineString",
-      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]], [], [[0, 0], [1, 0]]]
+      arcs: [[[0, 0], [1, 0], [1, 1], [0, 0]], [], [[0, 0], [1, 0]]]
     }
   });
   test.end();
@@ -317,11 +317,11 @@ tape("geometry does not convert empty polygons to null", function(test) {
   }), {
     foo: {
       type: "Polygon",
-      coordinates: []
+      arcs: []
     },
     bar: {
       type: "Polygon",
-      coordinates: [[]]
+      arcs: [[]]
     }
   });
   test.end();
@@ -336,7 +336,7 @@ tape("geometry does not strip empty polygons in multipolygons", function(test) {
   }), {
     foo: {
       type: "MultiPolygon",
-      coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 0]], []], [], [[]]]
+      arcs: [[[[0, 0], [1, 0], [1, 1], [0, 0]], []], [], [[]]]
     }
   });
   test.end();
@@ -351,7 +351,7 @@ tape("geometry does not convert singular multipolygons to polygons", function(te
   }), {
     foo: {
       type: "MultiPolygon",
-      coordinates: [[[[0, 0], [0, 1], [1, 0], [0, 0]]]]
+      arcs: [[[[0, 0], [0, 1], [1, 0], [0, 0]]]]
     }
   });
   test.end();

--- a/test/geometry-test.js
+++ b/test/geometry-test.js
@@ -154,6 +154,23 @@ tape("geometry preserves properties", function(test) {
   test.end();
 });
 
+tape("geometry applies a shallow copy for properties", function(test) {
+  var input = {
+    foo: {
+      properties: {
+        "foo": 42
+      },
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [[0, 0]]
+      }
+    }
+  }, output = geometry(input);
+  test.strictEqual(input.foo.properties, output.foo.properties);
+  test.end();
+});
+
 tape("geometry does not delete empty properties", function(test) {
   test.deepEqual(geometry({
     foo: {
@@ -174,7 +191,7 @@ tape("geometry does not delete empty properties", function(test) {
   test.end();
 });
 
-tape("geometry converts singular multipoints to points", function(test) {
+tape("geometry does not convert singular multipoints to points", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "MultiPoint",
@@ -182,14 +199,14 @@ tape("geometry converts singular multipoints to points", function(test) {
     }
   }), {
     foo: {
-      type: "Point",
-      coordinates: [0, 0]
+      type: "MultiPoint",
+      coordinates: [[0, 0]]
     }
   });
   test.end();
 });
 
-tape("geometry converts empty multipoints to null", function(test) {
+tape("geometry does not convert empty multipoints to null", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "MultiPoint",
@@ -197,13 +214,14 @@ tape("geometry converts empty multipoints to null", function(test) {
     }
   }), {
     foo: {
-      type: null
+      type: "MultiPoint",
+      coordinates: []
     }
   });
   test.end();
 });
 
-tape("geometry converts singular multilines to lines", function(test) {
+tape("geometry does not convert singular multilines to lines", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "MultiLineString",
@@ -211,14 +229,14 @@ tape("geometry converts singular multilines to lines", function(test) {
     }
   }), {
     foo: {
-      type: "LineString",
-      coordinates: [[0, 0], [0, 1]]
+      type: "MultiLineString",
+      coordinates: [[[0, 0], [0, 1]]]
     }
   });
   test.end();
 });
 
-tape("geometry converts empty lines to null", function(test) {
+tape("geometry does not convert empty lines to null", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "LineString",
@@ -226,13 +244,14 @@ tape("geometry converts empty lines to null", function(test) {
     }
   }), {
     foo: {
-      type: null
+      type: "LineString",
+      coordinates: []
     }
   });
   test.end();
 });
 
-tape("geometry converts empty multilines to null", function(test) {
+tape("geometry does not convert empty multilines to null", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "MultiLineString",
@@ -244,16 +263,18 @@ tape("geometry converts empty multilines to null", function(test) {
     }
   }), {
     foo: {
-      type: null
+      type: "MultiLineString",
+      coordinates: []
     },
     bar: {
-      type: null
+      type: "MultiLineString",
+      coordinates: [[]]
     }
   });
   test.end();
 });
 
-tape("geometry strips empty rings in polygons", function(test) {
+tape("geometry does not strip empty rings in polygons", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "Polygon",
@@ -262,13 +283,13 @@ tape("geometry strips empty rings in polygons", function(test) {
   }), {
     foo: {
       type: "Polygon",
-      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]]
+      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]], []]
     }
   });
   test.end();
 });
 
-tape("geometry strips empty lines in multilines", function(test) {
+tape("geometry does not strip empty lines in multilines", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "MultiLineString",
@@ -277,13 +298,13 @@ tape("geometry strips empty lines in multilines", function(test) {
   }), {
     foo: {
       type: "MultiLineString",
-      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]], [[0, 0], [1, 0]]]
+      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]], [], [[0, 0], [1, 0]]]
     }
   });
   test.end();
 });
 
-tape("geometry converts empty polygons to null", function(test) {
+tape("geometry does not convert empty polygons to null", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "Polygon",
@@ -295,16 +316,18 @@ tape("geometry converts empty polygons to null", function(test) {
     }
   }), {
     foo: {
-      type: null
+      type: "Polygon",
+      coordinates: []
     },
     bar: {
-      type: null
+      type: "Polygon",
+      coordinates: [[]]
     }
   });
   test.end();
 });
 
-tape("geometry strips empty polygons in multipolygons", function(test) {
+tape("geometry does not strip empty polygons in multipolygons", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "MultiPolygon",
@@ -312,14 +335,14 @@ tape("geometry strips empty polygons in multipolygons", function(test) {
     }
   }), {
     foo: {
-      type: "Polygon",
-      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]]
+      type: "MultiPolygon",
+      coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 0]], []], [], [[]]]
     }
   });
   test.end();
 });
 
-tape("geometry converts singular multipolygons to polygons", function(test) {
+tape("geometry does not convert singular multipolygons to polygons", function(test) {
   test.deepEqual(geometry({
     foo: {
       type: "MultiPolygon",
@@ -327,8 +350,8 @@ tape("geometry converts singular multipolygons to polygons", function(test) {
     }
   }), {
     foo: {
-      type: "Polygon",
-      coordinates: [[[0, 0], [0, 1], [1, 0], [0, 0]]]
+      type: "MultiPolygon",
+      coordinates: [[[[0, 0], [0, 1], [1, 0], [0, 0]]]]
     }
   });
   test.end();

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -5,8 +5,8 @@ var tape = require("tape"),
 
 tape("join the returned hashmap has true for junction points", function(test) {
   var junctions = join(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]}
   }));
   test.equal(junctions.has([2, 0]), true);
   test.equal(junctions.has([0, 0]), true);
@@ -15,8 +15,8 @@ tape("join the returned hashmap has true for junction points", function(test) {
 
 tape("join the returned hashmap has undefined for non-junction points", function(test) {
   var junctions = join(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [2, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [2, 0]]}
   }));
   test.equal(junctions.has([1, 0]), false);
   test.end();
@@ -24,8 +24,8 @@ tape("join the returned hashmap has undefined for non-junction points", function
 
 tape("join exact duplicate lines ABC & ABC have junctions at their end points", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abc2: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abc2: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [2, 0]]);
   test.end();
@@ -33,8 +33,8 @@ tape("join exact duplicate lines ABC & ABC have junctions at their end points", 
 
 tape("join reversed duplicate lines ABC & CBA have junctions at their end points", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [2, 0]]);
   test.end();
@@ -42,8 +42,8 @@ tape("join reversed duplicate lines ABC & CBA have junctions at their end points
 
 tape("join exact duplicate rings ABCA & ABCA have no junctions", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    abca2: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    abca2: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -51,8 +51,8 @@ tape("join exact duplicate rings ABCA & ABCA have no junctions", function(test) 
 
 tape("join reversed duplicate rings ACBA & ABCA have no junctions", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    acba: {type: "Polygon", coordinates: [[[0, 0], [2, 0], [1, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    acba: {type: "Polygon", arcs: [[[0, 0], [2, 0], [1, 0], [0, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -60,8 +60,8 @@ tape("join reversed duplicate rings ACBA & ABCA have no junctions", function(tes
 
 tape("join rotated duplicate rings BCAB & ABCA have no junctions", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
-    bcab: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [0, 0], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    bcab: {type: "Polygon", arcs: [[[1, 0], [2, 0], [0, 0], [1, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -69,8 +69,8 @@ tape("join rotated duplicate rings BCAB & ABCA have no junctions", function(test
 
 tape("join ring ABCA & line ABCA have a junction at A", function(test) {
   var junctions = join(extract({
-    abcaLine: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [0, 0]]},
-    abcaPolygon: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    abcaLine: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [0, 0]]},
+    abcaPolygon: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
   }));
   testSetEqual(test, junctions.values(), [[0, 0]]);
   test.end();
@@ -78,8 +78,8 @@ tape("join ring ABCA & line ABCA have a junction at A", function(test) {
 
 tape("join ring BCAB & line ABCA have a junction at A", function(test) {
   var junctions = join(extract({
-    abcaLine: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [0, 0]]},
-    bcabPolygon: {type: "Polygon", coordinates: [[[1, 0], [2, 0], [0, 0], [1, 0]]]},
+    abcaLine: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [0, 0]]},
+    bcabPolygon: {type: "Polygon", arcs: [[[1, 0], [2, 0], [0, 0], [1, 0]]]},
   }));
   testSetEqual(test, junctions.values(), [[0, 0]]);
   test.end();
@@ -87,8 +87,8 @@ tape("join ring BCAB & line ABCA have a junction at A", function(test) {
 
 tape("join ring ABCA & line BCAB have a junction at B", function(test) {
   var junctions = join(extract({
-    bcabLine: {type: "LineString", coordinates: [[1, 0], [2, 0], [0, 0], [1, 0]]},
-    abcaPolygon: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
+    bcabLine: {type: "LineString", arcs: [[1, 0], [2, 0], [0, 0], [1, 0]]},
+    abcaPolygon: {type: "Polygon", arcs: [[[0, 0], [1, 0], [2, 0], [0, 0]]]},
   }));
   testSetEqual(test, junctions.values(), [[1, 0]]);
   test.end();
@@ -96,8 +96,8 @@ tape("join ring ABCA & line BCAB have a junction at B", function(test) {
 
 tape("join when an old arc ABC extends a new arc AB, there is a junction at B", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [1, 0], [2, 0]]);
   test.end();
@@ -105,8 +105,8 @@ tape("join when an old arc ABC extends a new arc AB, there is a junction at B", 
 
 tape("join when a reversed old arc CBA extends a new arc AB, there is a junction at B", function(test) {
   var junctions = join(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [1, 0], [2, 0]]);
   test.end();
@@ -114,8 +114,8 @@ tape("join when a reversed old arc CBA extends a new arc AB, there is a junction
 
 tape("join when a new arc ADE shares its start with an old arc ABC, there is a junction at A", function(test) {
   var junctions = join(extract({
-    ade: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 1], [2, 1]]}
+    ade: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 1], [2, 1]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [2, 0], [2, 1]]);
   test.end();
@@ -123,7 +123,7 @@ tape("join when a new arc ADE shares its start with an old arc ABC, there is a j
 
 tape("join ring ABA has no junctions", function(test) {
   var junctions = join(extract({
-    aba: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 0]]]},
+    aba: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 0]]]},
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -131,7 +131,7 @@ tape("join ring ABA has no junctions", function(test) {
 
 tape("join ring AA has no junctions", function(test) {
   var junctions = join(extract({
-    aa: {type: "Polygon", coordinates: [[[0, 0], [0, 0]]]},
+    aa: {type: "Polygon", arcs: [[[0, 0], [0, 0]]]},
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -139,7 +139,7 @@ tape("join ring AA has no junctions", function(test) {
 
 tape("join degenerate ring A has no junctions", function(test) {
   var junctions = join(extract({
-    a: {type: "Polygon", coordinates: [[[0, 0]]]},
+    a: {type: "Polygon", arcs: [[[0, 0]]]},
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -147,8 +147,8 @@ tape("join degenerate ring A has no junctions", function(test) {
 
 tape("join when a new line DEC shares its end with an old line ABC, there is a junction at C", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dec: {type: "LineString", coordinates: [[0, 1], [1, 1], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dec: {type: "LineString", arcs: [[0, 1], [1, 1], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [2, 0], [0, 1]]);
   test.end();
@@ -156,8 +156,8 @@ tape("join when a new line DEC shares its end with an old line ABC, there is a j
 
 tape("join when a new line ABC extends an old line AB, there is a junction at B", function(test) {
   var junctions = join(extract({
-    ab: {type: "LineString", coordinates: [[0, 0], [1, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    ab: {type: "LineString", arcs: [[0, 0], [1, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [1, 0], [2, 0]]);
   test.end();
@@ -165,8 +165,8 @@ tape("join when a new line ABC extends an old line AB, there is a junction at B"
 
 tape("join when a new line ABC extends a reversed old line BA, there is a junction at B", function(test) {
   var junctions = join(extract({
-    ba: {type: "LineString", coordinates: [[1, 0], [0, 0]]},
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]}
+    ba: {type: "LineString", arcs: [[1, 0], [0, 0]]},
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [1, 0], [2, 0]]);
   test.end();
@@ -174,8 +174,8 @@ tape("join when a new line ABC extends a reversed old line BA, there is a juncti
 
 tape("join when a new line starts BC in the middle of an old line ABC, there is a junction at B", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    bc: {type: "LineString", coordinates: [[1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    bc: {type: "LineString", arcs: [[1, 0], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [1, 0], [2, 0]]);
   test.end();
@@ -183,8 +183,8 @@ tape("join when a new line starts BC in the middle of an old line ABC, there is 
 
 tape("join when a new line BC starts in the middle of a reversed old line CBA, there is a junction at B", function(test) {
   var junctions = join(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    bc: {type: "LineString", coordinates: [[1, 0], [2, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    bc: {type: "LineString", arcs: [[1, 0], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [1, 0], [2, 0]]);
   test.end();
@@ -192,8 +192,8 @@ tape("join when a new line BC starts in the middle of a reversed old line CBA, t
 
 tape("join when a new line ABD deviates from an old line ABC, there is a junction at B", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    abd: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    abd: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [2, 0], [1, 0], [3, 0]]);
   test.end();
@@ -201,8 +201,8 @@ tape("join when a new line ABD deviates from an old line ABC, there is a junctio
 
 tape("join when a new line ABD deviates from a reversed old line CBA, there is a junction at B", function(test) {
   var junctions = join(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    abd: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    abd: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[2, 0], [0, 0], [1, 0], [3, 0]]);
   test.end();
@@ -210,8 +210,8 @@ tape("join when a new line ABD deviates from a reversed old line CBA, there is a
 
 tape("join when a new line DBC merges into an old line ABC, there is a junction at B", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dbc: {type: "LineString", coordinates: [[3, 0], [1, 0], [2, 0]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dbc: {type: "LineString", arcs: [[3, 0], [1, 0], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [2, 0], [1, 0], [3, 0]]);
   test.end();
@@ -219,8 +219,8 @@ tape("join when a new line DBC merges into an old line ABC, there is a junction 
 
 tape("join when a new line DBC merges into a reversed old line CBA, there is a junction at B", function(test) {
   var junctions = join(extract({
-    cba: {type: "LineString", coordinates: [[2, 0], [1, 0], [0, 0]]},
-    dbc: {type: "LineString", coordinates: [[3, 0], [1, 0], [2, 0]]}
+    cba: {type: "LineString", arcs: [[2, 0], [1, 0], [0, 0]]},
+    dbc: {type: "LineString", arcs: [[3, 0], [1, 0], [2, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[2, 0], [0, 0], [1, 0], [3, 0]]);
   test.end();
@@ -228,8 +228,8 @@ tape("join when a new line DBC merges into a reversed old line CBA, there is a j
 
 tape("join when a new line DBE shares a single midpoint with an old line ABC, there is a junction at B", function(test) {
   var junctions = join(extract({
-    abc: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0]]},
-    dbe: {type: "LineString", coordinates: [[0, 1], [1, 0], [2, 1]]}
+    abc: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0]]},
+    dbe: {type: "LineString", arcs: [[0, 1], [1, 0], [2, 1]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [2, 0], [2, 1], [1, 0], [0, 1]]);
   test.end();
@@ -237,8 +237,8 @@ tape("join when a new line DBE shares a single midpoint with an old line ABC, th
 
 tape("join when a new line ABDE skips a point with an old line ABCDE, there is a junction at B and D", function(test) {
   var junctions = join(extract({
-    abcde: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]]},
-    abde: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0], [4, 0]]}
+    abcde: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]]},
+    abde: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0], [4, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [4, 0], [1, 0], [3, 0]]);
   test.end();
@@ -246,8 +246,8 @@ tape("join when a new line ABDE skips a point with an old line ABCDE, there is a
 
 tape("join when a new line ABDE skips a point with a reversed old line EDCBA, there is a junction at B and D", function(test) {
   var junctions = join(extract({
-    edcba: {type: "LineString", coordinates: [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]]},
-    abde: {type: "LineString", coordinates: [[0, 0], [1, 0], [3, 0], [4, 0]]}
+    edcba: {type: "LineString", arcs: [[4, 0], [3, 0], [2, 0], [1, 0], [0, 0]]},
+    abde: {type: "LineString", arcs: [[0, 0], [1, 0], [3, 0], [4, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[4, 0], [0, 0], [1, 0], [3, 0]]);
   test.end();
@@ -255,7 +255,7 @@ tape("join when a new line ABDE skips a point with a reversed old line EDCBA, th
 
 tape("join when a line ABCDBE self-intersects with its middle, there are no junctions", function(test) {
   var junctions = join(extract({
-    abcdbe: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]}
+    abcdbe: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [4, 0]]);
   test.end();
@@ -263,7 +263,7 @@ tape("join when a line ABCDBE self-intersects with its middle, there are no junc
 
 tape("join when a line ABACD self-intersects with its start, there are no junctions", function(test) {
   var junctions = join(extract({
-    abacd: {type: "LineString", coordinates: [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]]}
+    abacd: {type: "LineString", arcs: [[0, 0], [1, 0], [0, 0], [3, 0], [4, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [4, 0]]);
   test.end();
@@ -271,7 +271,7 @@ tape("join when a line ABACD self-intersects with its start, there are no juncti
 
 tape("join when a line ABCDBD self-intersects with its end, there are no junctions", function(test) {
   var junctions = join(extract({
-    abcdbd: {type: "LineString", coordinates: [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]]}
+    abcdbd: {type: "LineString", arcs: [[0, 0], [1, 0], [4, 0], [3, 0], [4, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [4, 0]]);
   test.end();
@@ -279,8 +279,8 @@ tape("join when a line ABCDBD self-intersects with its end, there are no junctio
 
 tape("join when an old line ABCDBE self-intersects and shares a point B, there is a junction at B", function(test) {
   var junctions = join(extract({
-    abcdbe: {type: "LineString", coordinates: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]},
-    fbg: {type: "LineString", coordinates: [[0, 1], [1, 0], [2, 1]]}
+    abcdbe: {type: "LineString", arcs: [[0, 0], [1, 0], [2, 0], [3, 0], [1, 0], [4, 0]]},
+    fbg: {type: "LineString", arcs: [[0, 1], [1, 0], [2, 1]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0], [4, 0], [1, 0], [0, 1], [2, 1]]);
   test.end();
@@ -288,7 +288,7 @@ tape("join when an old line ABCDBE self-intersects and shares a point B, there i
 
 tape("join when a line ABCA is closed, there is a junction at A", function(test) {
   var junctions = join(extract({
-    abca: {type: "LineString", coordinates: [[0, 0], [1, 0], [0, 1], [0, 0]]}
+    abca: {type: "LineString", arcs: [[0, 0], [1, 0], [0, 1], [0, 0]]}
   }));
   testSetEqual(test, junctions.values(), [[0, 0]]);
   test.end();
@@ -296,7 +296,7 @@ tape("join when a line ABCA is closed, there is a junction at A", function(test)
 
 tape("join when a ring ABCA is closed, there are no junctions", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -304,8 +304,8 @@ tape("join when a ring ABCA is closed, there are no junctions", function(test) {
 
 tape("join exact duplicate rings ABCA & ABCA share the arc ABCA", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    abca2: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    abca2: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -313,8 +313,8 @@ tape("join exact duplicate rings ABCA & ABCA share the arc ABCA", function(test)
 
 tape("join reversed duplicate rings ABCA & ACBA share the arc ABCA", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    acba: {type: "Polygon", coordinates: [[[0, 0], [0, 1], [1, 0], [0, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    acba: {type: "Polygon", arcs: [[[0, 0], [0, 1], [1, 0], [0, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -322,8 +322,8 @@ tape("join reversed duplicate rings ABCA & ACBA share the arc ABCA", function(te
 
 tape("join coincident rings ABCA & BCAB share the arc BCAB", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    bcab: {type: "Polygon", coordinates: [[[1, 0], [0, 1], [0, 0], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    bcab: {type: "Polygon", arcs: [[[1, 0], [0, 1], [0, 0], [1, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -331,8 +331,8 @@ tape("join coincident rings ABCA & BCAB share the arc BCAB", function(test) {
 
 tape("join coincident rings ABCA & BACB share the arc BCAB", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    bacb: {type: "Polygon", coordinates: [[[1, 0], [0, 0], [0, 1], [1, 0]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    bacb: {type: "Polygon", arcs: [[[1, 0], [0, 0], [0, 1], [1, 0]]]}
   }));
   testSetEqual(test, junctions.values(), []);
   test.end();
@@ -340,8 +340,8 @@ tape("join coincident rings ABCA & BACB share the arc BCAB", function(test) {
 
 tape("join coincident rings ABCA & DBED share the point B", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    dbed: {type: "Polygon", coordinates: [[[2, 1], [1, 0], [2, 2], [2, 1]]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    dbed: {type: "Polygon", arcs: [[[2, 1], [1, 0], [2, 2], [2, 1]]]}
   }));
   testSetEqual(test, junctions.values(), [[1, 0]]);
   test.end();
@@ -349,8 +349,8 @@ tape("join coincident rings ABCA & DBED share the point B", function(test) {
 
 tape("join coincident ring ABCA & line DBE share the point B", function(test) {
   var junctions = join(extract({
-    abca: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
-    dbe: {type: "LineString", coordinates: [[2, 1], [1, 0], [2, 2]]}
+    abca: {type: "Polygon", arcs: [[[0, 0], [1, 0], [0, 1], [0, 0]]]},
+    dbe: {type: "LineString", arcs: [[2, 1], [1, 0], [2, 2]]}
   }));
   testSetEqual(test, junctions.values(), [[2, 1], [2, 2], [1, 0]]);
   test.end();

--- a/test/prequantize-test.js
+++ b/test/prequantize-test.js
@@ -14,11 +14,11 @@ tape("prequantize converts coordinates to fixed precision", function(test) {
   var objects = {
     foo: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [0, 1], [0, 0]]
+      arcs: [[0, 0], [1, 0], [0, 1], [0, 0]]
     }
   };
   quantize(objects, [0, 0, 1, 1], 1e4);
-  test.deepEqual(objects.foo.coordinates, [[0, 0], [9999, 0], [0, 9999], [0, 0]]);
+  test.deepEqual(objects.foo.arcs, [[0, 0], [9999, 0], [0, 9999], [0, 0]]);
   test.end();
 });
 
@@ -26,11 +26,11 @@ tape("prequantize observes the quantization parameter", function(test) {
   var objects = {
     foo: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [0, 1], [0, 0]]
+      arcs: [[0, 0], [1, 0], [0, 1], [0, 0]]
     }
   };
   quantize(objects, [0, 0, 1, 1], 10);
-  test.deepEqual(objects.foo.coordinates, [[0, 0], [9, 0], [0, 9], [0, 0]]);
+  test.deepEqual(objects.foo.arcs, [[0, 0], [9, 0], [0, 9], [0, 0]]);
   test.end();
 });
 
@@ -38,11 +38,11 @@ tape("prequantize observes the bounding box", function(test) {
   var objects = {
     foo: {
       type: "LineString",
-      coordinates: [[0, 0], [1, 0], [0, 1], [0, 0]]
+      arcs: [[0, 0], [1, 0], [0, 1], [0, 0]]
     }
   };
   quantize(objects, [-1, -1, 2, 2], 10);
-  test.deepEqual(objects.foo.coordinates, [[3, 3], [6, 3], [3, 6], [3, 3]]);
+  test.deepEqual(objects.foo.arcs, [[3, 3], [6, 3], [3, 6], [3, 3]]);
   test.end();
 });
 
@@ -62,11 +62,11 @@ tape("prequantize skips coincident points in lines", function(test) {
   var objects = {
     foo: {
       type: "LineString",
-      coordinates: [[0, 0], [0.9, 0.9], [1.1, 1.1], [2, 2]]
+      arcs: [[0, 0], [0.9, 0.9], [1.1, 1.1], [2, 2]]
     }
   };
   quantize(objects, [0, 0, 2, 2], 3);
-  test.deepEqual(objects.foo.coordinates, [[0, 0], [1, 1], [2, 2]]);
+  test.deepEqual(objects.foo.arcs, [[0, 0], [1, 1], [2, 2]]);
   test.end();
 });
 
@@ -74,11 +74,11 @@ tape("prequantize skips coincident points in polygons", function(test) {
   var objects = {
     foo: {
       type: "Polygon",
-      coordinates: [[[0, 0], [0.9, 0.9], [1.1, 1.1], [2, 2], [0, 0]]]
+      arcs: [[[0, 0], [0.9, 0.9], [1.1, 1.1], [2, 2], [0, 0]]]
     }
   };
   quantize(objects, [0, 0, 2, 2], 3);
-  test.deepEqual(objects.foo.coordinates, [[[0, 0], [1, 1], [2, 2], [0, 0]]]);
+  test.deepEqual(objects.foo.arcs, [[[0, 0], [1, 1], [2, 2], [0, 0]]]);
   test.end();
 });
 
@@ -98,11 +98,11 @@ tape("prequantize includes closing point in degenerate lines", function(test) {
   var objects = {
     foo: {
       type: "LineString",
-      coordinates: [[1, 1], [1, 1], [1, 1]]
+      arcs: [[1, 1], [1, 1], [1, 1]]
     }
   };
   quantize(objects, [0, 0, 2, 2], 3);
-  test.deepEqual(objects.foo.coordinates, [[1, 1], [1, 1]]);
+  test.deepEqual(objects.foo.arcs, [[1, 1], [1, 1]]);
   test.end();
 });
 
@@ -110,10 +110,10 @@ tape("prequantize includes closing point in degenerate polygons", function(test)
   var objects = {
     foo: {
       type: "Polygon",
-      coordinates: [[[0.9, 1], [1.1, 1], [1.01, 1], [0.9, 1]]]
+      arcs: [[[0.9, 1], [1.1, 1], [1.01, 1], [0.9, 1]]]
     }
   };
   quantize(objects, [0, 0, 2, 2], 3);
-  test.deepEqual(objects.foo.coordinates, [[[1, 1], [1, 1], [1, 1], [1, 1]]]);
+  test.deepEqual(objects.foo.arcs, [[[1, 1], [1, 1], [1, 1], [1, 1]]]);
   test.end();
 });

--- a/test/topojson/empty.json
+++ b/test/topojson/empty.json
@@ -1,11 +1,11 @@
 {
   "type": "Topology",
   "objects": {
-    "multilinestring": {"type": null},
-    "multipoint": {"type": null},
-    "multipolygon": {"type": null},
-    "multipolygon2": {"type": null},
-    "polygon": {"type": null}
+    "multilinestring": {"type": "MultiLineString", "arcs": []},
+    "multipoint": {"type": "MultiPoint", "coordinates": []},
+    "multipolygon": {"type": "MultiPolygon", "arcs": []},
+    "multipolygon2": {"type": "MultiPolygon", "arcs": [[]]},
+    "polygon": {"type": "Polygon", "arcs": []}
   },
   "arcs": []
 }

--- a/test/topology-test.js
+++ b/test/topology-test.js
@@ -1018,7 +1018,7 @@ tape("topology collapsed polygons in a MultiPolygon are preserved", function(tes
 tape("topology collapsed geometries in a GeometryCollection are preserved", function(test) {
   var topology = topojson.topology({collection: {type: "FeatureCollection", features: [{type: "Feature", geometry: {type: "MultiPolygon", coordinates: []}}]}}, 2);
   test.equal(topology.arcs.length, 0);
-  test.deepEqual(topology.objects.collection, {type: "GeometryCollection", geometries: [{type: null}]});
+  test.deepEqual(topology.objects.collection, {type: "GeometryCollection", geometries: [{type: "MultiPolygon", arcs: []}]});
   test.end();
 });
 
@@ -1027,7 +1027,7 @@ tape("topology collapsed geometries in a GeometryCollection are preserved", func
 tape("topology empty geometries are not removed", function(test) {
   var topology = topojson.topology({foo: {type: "MultiPolygon", coordinates: []}}, 2);
   test.equal(topology.arcs.length, 0);
-  test.deepEqual(topology.objects.foo, {type: null});
+  test.deepEqual(topology.objects.foo, {type: "MultiPolygon", arcs: []});
   test.end();
 });
 
@@ -1037,8 +1037,8 @@ tape("topology empty polygons are not removed", function(test) {
     bar: {type: "Polygon", coordinates: []}
   });
   test.equal(topology.arcs.length, 0);
-  test.deepEqual(topology.objects.foo, {type: "GeometryCollection", geometries: [{type: null}]});
-  test.deepEqual(topology.objects.bar, {type: null});
+  test.deepEqual(topology.objects.foo, {type: "GeometryCollection", geometries: [{type: "MultiPolygon", arcs: [[]]}]});
+  test.deepEqual(topology.objects.bar, {type: "Polygon", arcs: []});
   test.end();
 });
 

--- a/test/topology-test.js
+++ b/test/topology-test.js
@@ -877,7 +877,7 @@ tape("topology converting a feature to a geometry preserves its bbox", function(
   test.end();
 });
 
-tape("topology converting a feature to a geometry preserves its properties", function(test) {
+tape("topology converting a feature to a geometry preserves its properties, but only if non-empty", function(test) {
   var topology = topojson.topology({foo: {type: "Feature", id: "Foo", properties: {name: "George"}, geometry: {type: "LineString", coordinates: [[.1, .2], [.3, .4]]}}});
   test.deepEqual(topology.objects.foo.properties, {name: "George"});
   var topology = topojson.topology({foo: {type: "Feature", id: "Foo", properties: {name: "George"}, geometry: {type: "GeometryCollection", geometries: [{type: "LineString", coordinates: [[.1, .2], [.3, .4]]}]}}});
@@ -885,7 +885,7 @@ tape("topology converting a feature to a geometry preserves its properties", fun
   var topology = topojson.topology({foo: {type: "Feature", id: "Foo", properties: {name: "George", demeanor: "curious"}, geometry: {type: "LineString", coordinates: [[.1, .2], [.3, .4]]}}});
   test.deepEqual(topology.objects.foo.properties, {name: "George", demeanor: "curious"});
   var topology = topojson.topology({foo: {type: "Feature", id: "Foo", properties: {}, geometry: {type: "LineString", coordinates: [[.1, .2], [.3, .4]]}}});
-  test.deepEqual(topology.objects.foo.properties, {});
+  test.equal(topology.objects.foo.properties, undefined);
   test.end();
 });
 

--- a/test/topology-test.js
+++ b/test/topology-test.js
@@ -999,7 +999,7 @@ tape("topology collapsed polygons are preserved", function(test) {
   }, 3);
   test.deepEqual(topology.objects.foo, {type: "Polygon", arcs: [[0]]});
   test.deepEqual(topology.objects.bar, {type: "Polygon", arcs: [[0]]});
-  test.deepEqual(topology.arcs[0], [[1, 1], [0, 0], [0, 0], [0, 0]]);
+  test.deepEqual(topology.arcs[0], [[1, 1], [0, 0]]);
   test.end();
 });
 


### PR DESCRIPTION
This fixes #2, changing [topojson.topology](https://github.com/topojson/topojson-server/blob/non-destructive/README.md#topology) so that it no longer destroys the input objects; instead, shallow copies are made as needed.

This also fixes #3 by removing type reduction: for example, an input MultiPolygon geometry with only a single polygon is no longer reduced to a Polygon, and an input empty MultiLineString geometry is no longer reduced to a null geometry. The output type of a geometry object is always the same as its input type. You can remove null geometries using [topojson.filter](https://github.com/topojson/topojson-simplify/blob/non-destructive/README.md#filter).

**This will be a major version change, released as 3.0.**

For the other changes in 3.0, see:

* topojson/topojson-client#11
* topojson/topojson-simplify#6
* topojson/topojson#305
