### PR TITLE
Update geo2topo

### DIFF
--- a/bin/geo2topo
+++ b/bin/geo2topo
@@ -13,6 +13,7 @@ commander
     .option("-o, --out <file>", "output file name; defaults to “-” for stdout", "-")
     .option("-n, --newline-delimited", "accept newline-delimited JSON")
     .option("-q, --quantization <count>", "pre-quantization parameter; 0 disables quantization", 0)
+    .option("-l, --split-layers", "accept newline-delimited JSON")
     .parse(process.argv);
 
 if (commander.args.length < 1) commander.args[0] = "-";
@@ -37,7 +38,19 @@ function read(specifier) {
   objects[name] = undefined;
   return (commander.newlineDelimited ? readNewlineDelimitedObject : readObject)(file === "-"
       ? process.stdin : fs.createReadStream(file))
-      .then(function(object) { objects[name] = object; });
+      .then(function(object) {
+      	if (commander.splitLayers) {
+      		object.features.foreach(function(element) {
+      			var layer = element.properties.layer ? element.properties.layer : name;
+      			if (typeof objects[layer] === 'undefined') {
+      				objects[layer] = { type: 'FeatureCollection', features: [] };
+  				}
+  				objects[layer].features.push(element);
+      		});
+  		} else {
+  			objects[name] = object;
+  		} 
+      });
 }
 
 function readNewlineDelimitedObject(stream) {


### PR DESCRIPTION
I regularly go through the following process to go from ndjson (convenient for modifying data) to geojson (to project) and then to topojson to simplify and use.
($states; $objects) 
| ndjson-reduce 'p.features.push(d), p' '{type: \"FeatureCollection\", features: []}'
| geostitch
| geoproject 'd3.geoMercator().rotate([" . (0 - $row[centroid_x]) . ", " . (0 - $row[centroid_y]) . "]).fitSize([$px_width, $px_height], d)'
| geo2topo all=-
| toposimplify --filter-all -p 1

The issue is that I need all of the data in a single geojson file so that I can use .fitSize() and maintain the same scale for all layers, but then when using it, I would much rather have the topojson split into layers.

The pull request would allow you to change the geo2topo command to "| geo2topo --split-layers" and use ndjson-map to specify the layer as a property of each like this:

($states | ndjson-map 'd.properties.layer = "states", d'; $objects | ndjson-map 'd.properties.layer = "objects", d') 
| ndjson-reduce 'p.features.push(d), p' '{type: \"FeatureCollection\", features: []}'
| geostitch
| geoproject 'd3.geoMercator().rotate([" . (0 - $row[centroid_x]) . ", " . (0 - $row[centroid_y]) . "]).fitSize([$px_width, $px_height], d)'
| geo2topo --split-layers
| toposimplify --filter-all -p 1