### PR TITLE
show info with no arguments

### DIFF
--- a/bin/geo2topo
+++ b/bin/geo2topo
@@ -15,7 +15,10 @@ commander
     .option("-q, --quantization <count>", "pre-quantization parameter; 0 disables quantization", 0)
     .parse(process.argv);
 
-if (commander.args.length < 1) commander.args[0] = "-";
+if (commander.args.length < 1) {
+  console.log(commander.helpInformation());
+  process.exit(0);
+}
 
 var nullType = {},
     nullObject = {type: nullType},


### PR DESCRIPTION
`geo2topo` hangs when a user doesn't provide an argument. 

This PR prints `-h` information and exits when running just `geo2topo`.